### PR TITLE
fix: change minimum sdk version 2.12.0 and remove unused dependencies and release v0.0.1-dev.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## [0.0.1-dev.3]
+## [0.0.1-dev.5]
+
+- fix: Change the minimul SDK version to 2.12.0
+
+## [0.0.1-dev.4]
 
 - fix: Fix a bug where json is not properly encoded.
-- fix: Set default headers with X-Client-Info. 
+- fix: Set default headers with X-Client-Info.
 
 ## [0.0.1-dev.3]
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
-include: package:lint/analysis_options.yaml
-
-linter:
-  rules:
-    avoid_print: false
+include: package:lints/recommended.yaml

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.0.1-dev.4';
+const version = '0.0.1-dev.5';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,15 @@
 name: functions_client
 description: A dart client library for the Supabase functions.
-version: 0.0.1-dev.4
+version: 0.0.1-dev.5
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase-community/functions-dart'
 
 environment:
-  sdk: '>=2.16.1 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   http: ^0.13.4
 
 dev_dependencies:
-  dotenv: ^3.0.0
-  lint: ^1.5.1
+  lints: ^1.0.1
   test: ^1.16.4


### PR DESCRIPTION
- Updated the version to `0.0.1-dev.5`
- Using `lints` package instead of `lint`
- Change the minimul SDK version to 2.12.0