### PR TITLE
Rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.0.0-dev.3]
+
+- BREAKING: `error` is now thrown instead of being returned within a response
+```dart
+try {
+  final res = await functions.invoke('myFunction');
+  print(res.data);
+} catch (error, stacktrace) {
+  print('$error \n $stracktrace');
+}
+```
+
 ## [1.0.0-dev.2]
 
 - feat: use isolates for json encoding/decoding

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -41,30 +41,26 @@ class FunctionsClient {
     Map<String, dynamic>? body,
     ResponseType responseType = ResponseType.json,
   }) async {
-    try {
-      final bodyStr = await compute(json.encode, body);
+    final bodyStr = await compute(json.encode, body);
 
-      final response = await (_httpClient?.post ?? http.post)(
-        Uri.parse('$_url/$functionName'),
-        headers: <String, String>{..._headers, if (headers != null) ...headers},
-        body: bodyStr,
-      );
+    final response = await (_httpClient?.post ?? http.post)(
+      Uri.parse('$_url/$functionName'),
+      headers: <String, String>{..._headers, if (headers != null) ...headers},
+      body: bodyStr,
+    );
 
-      final dynamic data;
-      if (responseType == ResponseType.json) {
-        data = await compute(json.decode, response.body);
-      } else if (responseType == ResponseType.blob) {
-        data = response.bodyBytes;
-      } else if (responseType == ResponseType.arraybuffer) {
-        data = response.bodyBytes;
-      } else if (responseType == ResponseType.text) {
-        data = response.body;
-      } else {
-        data = response.body;
-      }
-      return FunctionResponse(data: data, status: response.statusCode);
-    } catch (error) {
-      return FunctionResponse(error: error);
+    final dynamic data;
+    if (responseType == ResponseType.json) {
+      data = await compute(json.decode, response.body);
+    } else if (responseType == ResponseType.blob) {
+      data = response.bodyBytes;
+    } else if (responseType == ResponseType.arraybuffer) {
+      data = response.bodyBytes;
+    } else if (responseType == ResponseType.text) {
+      data = response.body;
+    } else {
+      data = response.body;
     }
+    return FunctionResponse(data: data, status: response.statusCode);
   }
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -19,12 +19,10 @@ class FunctionInvokeOptions {
 
 class FunctionResponse {
   final dynamic data;
-  final Object? error;
   final int? status;
 
   FunctionResponse({
     this.data,
-    this.error,
     this.status,
   });
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.2';
+const version = '1.0.0-dev.3';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: functions_client
 description: A dart client library for the Supabase functions.
-version: 1.0.0-dev.2
+version: 1.0.0-dev.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase-community/functions-dart'
 


### PR DESCRIPTION
Finishes the [rework](https://github.com/supabase-community/supabase-dart/issues/109)
I think we should return the status, so I'm still wrapping `data` in a response, but throwing the error.
We don't need a specifc `FunctionsExeception`, right?  We could implement a status code checking and throw on e.g. `404`. What do you think?