### PR TITLE
Support null body when invoking functions

### DIFF
--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -51,8 +51,8 @@ class FunctionsClient {
 
     final dynamic data;
     if (responseType == ResponseType.json) {
-      final body = response.body;
-      data = body?.isEmpty ?? true ? null : await compute(json.decode, body);
+      final resBody = response.body;
+      data = resBody.isEmpty ? null : await compute(json.decode, resBody);
     } else if (responseType == ResponseType.blob) {
       data = response.bodyBytes;
     } else if (responseType == ResponseType.arraybuffer) {

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -52,7 +52,7 @@ class FunctionsClient {
     final dynamic data;
     if (responseType == ResponseType.json) {
       final body = response.body;
-      data = body?.isEmpty ?? true ? null : await compute(json.decode, response.body);
+      data = body?.isEmpty ?? true ? null : await compute(json.decode, body);
     } else if (responseType == ResponseType.blob) {
       data = response.bodyBytes;
     } else if (responseType == ResponseType.arraybuffer) {

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -41,7 +41,7 @@ class FunctionsClient {
     Map<String, dynamic>? body,
     ResponseType responseType = ResponseType.json,
   }) async {
-    final bodyStr = await compute(json.encode, body);
+    final bodyStr = body == null ? null : await compute(json.encode, body);
 
     final response = await (_httpClient?.post ?? http.post)(
       Uri.parse('$_url/$functionName'),

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -52,7 +52,7 @@ class FunctionsClient {
     final dynamic data;
     if (responseType == ResponseType.json) {
       final resBody = response.body;
-      data = resBody.isEmpty ? null : await compute(json.decode, resBody);
+      data = resBody.isEmpty ? resBody : await compute(json.decode, resBody);
     } else if (responseType == ResponseType.blob) {
       data = response.bodyBytes;
     } else if (responseType == ResponseType.arraybuffer) {

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -51,7 +51,8 @@ class FunctionsClient {
 
     final dynamic data;
     if (responseType == ResponseType.json) {
-      data = await compute(json.decode, response.body);
+      final body = response.body;
+      data = body?.isEmpty ?? true ? null : await compute(json.decode, response.body);
     } else if (responseType == ResponseType.blob) {
       data = response.bodyBytes;
     } else if (responseType == ResponseType.arraybuffer) {


### PR DESCRIPTION
Currently, when the body is null, the json.encode method will cast it to a string as part of the encoding. This results in the body containing `"null"` which can break some server-side json implementations.