### PR TITLE
fix: test against Dart 2.15.0 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.14.0, stable, beta, dev]
+        sdk: [2.15.0, stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   test:
-    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }} / SDK ${{ matrix.sdk }}
+    name: Test / SDK ${{ matrix.sdk }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [stable, beta, dev]
+        sdk: [2.14.0, stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Test / SDK ${{ matrix.sdk }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ['12']

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase-community/functions-dart'
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   http: ^0.13.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   http: ^0.13.4
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^1.0.1
   test: ^1.16.4


### PR DESCRIPTION
- Adds tests in CI to test the library against Dart v2.15.0 

Changed the version to 2.15.0, because `Isolate.exit()` was introduced in Dart v2.15.0. Will make all libraries using isolates to 2.15.0. 