### PR TITLE
fix: use utf8 encoding for text response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.1]
+
+- fix: use utf8 encoding for text response
+
 ## [1.1.0]
 
 - feat: add `method` parameter to `invoke()` to support all GET, POST, PUT, PATCH, DELETE methods

--- a/lib/src/functions_client.dart
+++ b/lib/src/functions_client.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:functions_client/src/constants.dart';
 import 'package:functions_client/src/types.dart';
 import 'package:http/http.dart' as http;
@@ -49,57 +51,48 @@ class FunctionsClient {
     final bodyStr = body == null ? null : await _isolate.encode(body);
 
     late final Response response;
+    final uri = Uri.parse('$_url/$functionName');
+
+    final finalHeaders = <String, String>{
+      ..._headers,
+      if (headers != null) ...headers
+    };
 
     switch (method) {
       case HttpMethod.post:
         response = await (_httpClient?.post ?? http.post)(
-          Uri.parse('$_url/$functionName'),
-          headers: <String, String>{
-            ..._headers,
-            if (headers != null) ...headers
-          },
+          uri,
+          headers: finalHeaders,
           body: bodyStr,
         );
         break;
 
       case HttpMethod.get:
         response = await (_httpClient?.get ?? http.get)(
-          Uri.parse('$_url/$functionName'),
-          headers: <String, String>{
-            ..._headers,
-            if (headers != null) ...headers
-          },
+          uri,
+          headers: finalHeaders,
         );
         break;
 
       case HttpMethod.put:
         response = await (_httpClient?.put ?? http.put)(
-          Uri.parse('$_url/$functionName'),
-          headers: <String, String>{
-            ..._headers,
-            if (headers != null) ...headers
-          },
+          uri,
+          headers: finalHeaders,
           body: bodyStr,
         );
         break;
 
       case HttpMethod.delete:
         response = await (_httpClient?.delete ?? http.delete)(
-          Uri.parse('$_url/$functionName'),
-          headers: <String, String>{
-            ..._headers,
-            if (headers != null) ...headers
-          },
+          uri,
+          headers: finalHeaders,
         );
         break;
 
       case HttpMethod.patch:
         response = await (_httpClient?.patch ?? http.patch)(
-          Uri.parse('$_url/$functionName'),
-          headers: <String, String>{
-            ..._headers,
-            if (headers != null) ...headers
-          },
+          uri,
+          headers: finalHeaders,
           body: bodyStr,
         );
         break;
@@ -114,7 +107,7 @@ class FunctionsClient {
     } else if (responseType == ResponseType.arraybuffer) {
       data = response.bodyBytes;
     } else if (responseType == ResponseType.text) {
-      data = response.body;
+      data = utf8.decode(response.bodyBytes);
     } else {
       data = response.body;
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.1.0';
+const version = '1.1.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: functions_client
 description: A dart client library for the Supabase functions.
-version: 1.1.0
+version: 1.1.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase-community/functions-dart'
 


### PR DESCRIPTION
close supabase/supabase-flutter#367

From `Response.body`:
>   /// The body of the response as a string.
  ///
  /// This is converted from [bodyBytes] using the `charset` parameter of the
  /// `Content-Type` header field, if available. If it's unavailable or if the
  /// encoding name is unknown, [latin1] is used by default, as per
  /// [RFC 2616][].
  ///
  /// [RFC 2616]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html

So we can either always use utf8(as changed in this pr) or the user has to specify their headers correctly.