### PR TITLE
chore: update readme to redirect people to monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # `functions-dart`
 
+> **Warning**
+> This repository has been moved [supabase-flutter repo](https://github.com/supabase/supabase-flutter/tree/main/packages/functions_client).
+
 ## Contributing
 
 - Fork the repo on [GitHub](https://github.com/supabase-community/functions-dart)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `functions-dart`
 
 > **Warning**
-> This repository has been moved [supabase-flutter repo](https://github.com/supabase/supabase-flutter/tree/main/packages/functions_client).
+> This repository has been moved to the [supabase-flutter repo](https://github.com/supabase/supabase-flutter/tree/main/packages/functions_client).
 
 ## Contributing
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the readme to redirect people to supabase-flutter repo.

